### PR TITLE
Confusion about the scripts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ component: {
     output: './dist/',
     config: './component.json',
     styles: false,
-    scripts: [ 'src/**/*.js' ],
+    scripts: true,
     standalone: true
   }
 }
@@ -42,7 +42,7 @@ component: {
     output: './dist/',
     config: './component.json',
     styles: false,
-    scripts: [ 'src/**/*.js' ],
+    scripts: true,
     standalone: true,
     configure: function(builder) {
       builder.use(myPlugin);
@@ -67,7 +67,7 @@ component: {
     output: './dist/',
     config: './component.json',
     styles: false,
-    scripts: [ 'src/**/*.js' ],
+    scripts: true,
     standalone: true,
     plugins: ['coffee', 'templates']
   }
@@ -98,9 +98,9 @@ You don't need to add the `.js` extension when requiring the coffee files. Each 
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [grunt][grunt].
 
 ## Release History
-0.2.0beta - Added support for grunt 0.4.0
-0.1.4 - Added builder.js plugin support
-0.1.0 - First release
+0.2.0beta - Added support for grunt 0.4.0  
+0.1.4 - Added builder.js plugin support  
+0.1.0 - First release  
 
 ## License
 Copyright (c) 2012 Anthony Short  


### PR DESCRIPTION
Examples were confusing about the `scripts` option.
It showed that we were able to define some script paths with `scripts: [ 'src/**/*.js' ]` but the build script just check if `opts.scripts !== false`.
