### PR TITLE
Add new unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/*
+/tmp/

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 /node_modules/
+/tmp/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,15 +4,21 @@ module.exports = function(grunt) {
 
   // Project configuration.
   grunt.initConfig({
-    nodeunit: {
-      files: ['test/**/*_test.js']
+    clean: {
+      test: ['tmp']
     },
+
+    nodeunit: {
+      test: ['test/**/*_test.js']
+    },
+
     watch: {
-      files: '<config:lint.files>',
+      files: '<%= jshint.all %>',
       tasks: 'default'
     },
+
     jshint: {
-      all: ['Gruntfile.js', 'tasks/**/*.js', 'test/**/*.js'],
+      all: ['Gruntfile.js', 'tasks/**/*.js', '<%= nodeunit.test %>'],
       options: {
         curly: true,
         eqeqeq: true,
@@ -43,6 +49,7 @@ module.exports = function(grunt) {
   });
 
   // Load plugins
+  grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
@@ -50,7 +57,11 @@ module.exports = function(grunt) {
   // Load local tasks.
   grunt.loadTasks('tasks');
 
+  // Whenever the "test" task is run, first clean the "tmp" dir, then run this
+  // plugin's task(s), then test the result.
+  grunt.registerTask('test', ['clean', 'component', 'nodeunit']);
+
   // Default task.
-  grunt.registerTask('default', ['jshint', 'nodeunit']);
+  grunt.registerTask('default', ['jshint', 'test']);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,14 +36,27 @@ module.exports = function(grunt) {
       }
     },
 
+    // Configuration to be run (and then tested).
     component: {
-      output: 'dist/',
-      dev: false,
-      standalone: 'name',
-      name: 'file',
-      prefix: 'css',
-      plugins: ['templates', 'coffee'],
-      configure: function(builder){
+      test_build_dev: {
+        output: './tmp/',
+        dev: true,
+        sourceUrls: true,
+        name: 'build-dev'
+      },
+      test_build_prod: {
+        output: './tmp/',
+        dev: false,
+        sourceUrls: false,
+        name: 'build-prod'
+      },
+      test_standalone: {
+        output: './tmp/',
+        dev: false,
+        styles: false,
+        sourceUrls: false,
+        standalone: '$',
+        name: 'standalone'
       }
     }
   });

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ expected-prod:
 	@component build -o $(DIR) -n build-prod
 
 standalone:
-	@component build -o $(DIR) -n standalone -s Test
+	@component build -o $(DIR) -n standalone -s $$
 
 clean:
 	rm -fr $(DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+DIR = test/expected
+
+expected: clean expected-dev expected-prod standalone
+
+expected-dev:
+	@component build -o $(DIR) -n build-dev --dev
+
+expected-prod:
+	@component build -o $(DIR) -n build-prod
+
+standalone:
+	@component build -o $(DIR) -n standalone -s Test
+
+clean:
+	rm -fr $(DIR)
+
+.PHONY: expected

--- a/component.json
+++ b/component.json
@@ -1,0 +1,9 @@
+{
+  "name": "grunt-component-build-test",
+  "scripts": [
+    "test/fixtures/index.js"
+  ],
+  "styles": [
+    "test/fixtures/test.css"
+  ]
+}

--- a/component.json
+++ b/component.json
@@ -1,5 +1,6 @@
 {
   "name": "grunt-component-build-test",
+  "main": "test/fixtures/index.js",
   "scripts": [
     "test/fixtures/index.js"
   ],

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "grunt": "~0.4.0",
     "grunt-contrib-watch": "~0.2.0",
     "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-nodeunit": "~0.1.2"
+    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt-contrib-clean": "~0.4.0rc6"
   },
   "keywords": [
     "gruntplugin",

--- a/test/component_test.js
+++ b/test/component_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var grunt = require('grunt');
+var read = grunt.file.read;
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -23,14 +24,47 @@ var grunt = require('grunt');
 */
 
 exports['component'] = {
-  setUp: function(done) {
-    // setup here
-    done();
+  build_dev: function(test) {
+    test.expect(2);
+
+    var actual = read('tmp/build-dev.js');
+    var expected = read('test/expected/build-dev.js');
+
+    test.equal(actual, expected, 'should have the same output');
+
+    actual = read('tmp/build-dev.css');
+    expected = read('test/expected/build-dev.css');
+
+    test.equal(actual, expected, 'should have the same output');
+
+    test.done();
   },
-  'helper': function(test) {
+
+  build_prod: function(test) {
+    test.expect(2);
+
+    var actual = read('tmp/build-prod.js');
+    var expected = read('test/expected/build-prod.js');
+
+    test.equal(actual, expected, 'should have the same output');
+
+    actual = read('tmp/build-prod.css');
+    expected = read('test/expected/build-prod.css');
+
+    test.equal(actual, expected, 'should have the same output');
+
+    test.done();
+  },
+
+  standalone: function(test) {
     test.expect(1);
-    // tests here
-    test.ok(require('../tasks/component'), 'should return the correct value.');
+
+    var actual = read('tmp/standalone.js');
+    var expected = read('test/expected/standalone.js');
+
+    test.equal(actual, expected, 'should have the same output');
+
     test.done();
   }
+
 };

--- a/test/expected/build-dev.css
+++ b/test/expected/build-dev.css
@@ -1,0 +1,4 @@
+div {
+  margin: 0;
+  padding: 0;
+}

--- a/test/expected/build-dev.js
+++ b/test/expected/build-dev.js
@@ -1,0 +1,213 @@
+
+
+/**
+ * hasOwnProperty.
+ */
+
+var has = Object.prototype.hasOwnProperty;
+
+/**
+ * Require the given path.
+ *
+ * @param {String} path
+ * @return {Object} exports
+ * @api public
+ */
+
+function require(path, parent, orig) {
+  var resolved = require.resolve(path);
+
+  // lookup failed
+  if (null == resolved) {
+    orig = orig || path;
+    parent = parent || 'root';
+    var err = new Error('Failed to require "' + orig + '" from "' + parent + '"');
+    err.path = orig;
+    err.parent = parent;
+    err.require = true;
+    throw err;
+  }
+
+  var module = require.modules[resolved];
+
+  // perform real require()
+  // by invoking the module's
+  // registered function
+  if (!module.exports) {
+    module.exports = {};
+    module.client = module.component = true;
+    module.call(this, module.exports, require.relative(resolved), module);
+  }
+
+  return module.exports;
+}
+
+/**
+ * Registered modules.
+ */
+
+require.modules = {};
+
+/**
+ * Registered aliases.
+ */
+
+require.aliases = {};
+
+/**
+ * Resolve `path`.
+ *
+ * Lookup:
+ *
+ *   - PATH/index.js
+ *   - PATH.js
+ *   - PATH
+ *
+ * @param {String} path
+ * @return {String} path or null
+ * @api private
+ */
+
+require.resolve = function(path) {
+  if (path.charAt(0) === '/') path = path.slice(1);
+  var index = path + '/index.js';
+
+  var paths = [
+    path,
+    path + '.js',
+    path + '.json',
+    path + '/index.js',
+    path + '/index.json'
+  ];
+
+  for (var i = 0; i < paths.length; i++) {
+    var path = paths[i];
+    if (has.call(require.modules, path)) return path;
+  }
+
+  if (has.call(require.aliases, index)) {
+    return require.aliases[index];
+  }
+};
+
+/**
+ * Normalize `path` relative to the current path.
+ *
+ * @param {String} curr
+ * @param {String} path
+ * @return {String}
+ * @api private
+ */
+
+require.normalize = function(curr, path) {
+  var segs = [];
+
+  if ('.' != path.charAt(0)) return path;
+
+  curr = curr.split('/');
+  path = path.split('/');
+
+  for (var i = 0; i < path.length; ++i) {
+    if ('..' == path[i]) {
+      curr.pop();
+    } else if ('.' != path[i] && '' != path[i]) {
+      segs.push(path[i]);
+    }
+  }
+
+  return curr.concat(segs).join('/');
+};
+
+/**
+ * Register module at `path` with callback `definition`.
+ *
+ * @param {String} path
+ * @param {Function} definition
+ * @api private
+ */
+
+require.register = function(path, definition) {
+  require.modules[path] = definition;
+};
+
+/**
+ * Alias a module definition.
+ *
+ * @param {String} from
+ * @param {String} to
+ * @api private
+ */
+
+require.alias = function(from, to) {
+  if (!has.call(require.modules, from)) {
+    throw new Error('Failed to alias "' + from + '", it does not exist');
+  }
+  require.aliases[to] = from;
+};
+
+/**
+ * Return a require function relative to the `parent` path.
+ *
+ * @param {String} parent
+ * @return {Function}
+ * @api private
+ */
+
+require.relative = function(parent) {
+  var p = require.normalize(parent, '..');
+
+  /**
+   * lastIndexOf helper.
+   */
+
+  function lastIndexOf(arr, obj) {
+    var i = arr.length;
+    while (i--) {
+      if (arr[i] === obj) return i;
+    }
+    return -1;
+  }
+
+  /**
+   * The relative require() itself.
+   */
+
+  function localRequire(path) {
+    var resolved = localRequire.resolve(path);
+    return require(resolved, parent, path);
+  }
+
+  /**
+   * Resolve relative to the parent.
+   */
+
+  localRequire.resolve = function(path) {
+    var c = path.charAt(0);
+    if ('/' == c) return path.slice(1);
+    if ('.' == c) return require.normalize(p, path);
+
+    // resolve deps by returning
+    // the dep in the nearest "deps"
+    // directory
+    var segs = parent.split('/');
+    var i = lastIndexOf(segs, 'deps') + 1;
+    if (!i) i = 0;
+    path = segs.slice(0, i + 1).join('/') + '/deps/' + path;
+    return path;
+  };
+
+  /**
+   * Check if module is defined at `path`.
+   */
+
+  localRequire.exists = function(path) {
+    return has.call(require.modules, localRequire.resolve(path));
+  };
+
+  return localRequire;
+};
+require.register("grunt-component-build-test/test/fixtures/index.js", Function("exports, require, module",
+"module.exports = 'test';//@ sourceURL=grunt-component-build-test/test/fixtures/index.js"
+));
+require.alias("grunt-component-build-test/test/fixtures/index.js", "grunt-component-build-test/index.js");
+

--- a/test/expected/build-prod.css
+++ b/test/expected/build-prod.css
@@ -1,0 +1,4 @@
+div {
+  margin: 0;
+  padding: 0;
+}

--- a/test/expected/build-prod.js
+++ b/test/expected/build-prod.js
@@ -1,0 +1,213 @@
+
+
+/**
+ * hasOwnProperty.
+ */
+
+var has = Object.prototype.hasOwnProperty;
+
+/**
+ * Require the given path.
+ *
+ * @param {String} path
+ * @return {Object} exports
+ * @api public
+ */
+
+function require(path, parent, orig) {
+  var resolved = require.resolve(path);
+
+  // lookup failed
+  if (null == resolved) {
+    orig = orig || path;
+    parent = parent || 'root';
+    var err = new Error('Failed to require "' + orig + '" from "' + parent + '"');
+    err.path = orig;
+    err.parent = parent;
+    err.require = true;
+    throw err;
+  }
+
+  var module = require.modules[resolved];
+
+  // perform real require()
+  // by invoking the module's
+  // registered function
+  if (!module.exports) {
+    module.exports = {};
+    module.client = module.component = true;
+    module.call(this, module.exports, require.relative(resolved), module);
+  }
+
+  return module.exports;
+}
+
+/**
+ * Registered modules.
+ */
+
+require.modules = {};
+
+/**
+ * Registered aliases.
+ */
+
+require.aliases = {};
+
+/**
+ * Resolve `path`.
+ *
+ * Lookup:
+ *
+ *   - PATH/index.js
+ *   - PATH.js
+ *   - PATH
+ *
+ * @param {String} path
+ * @return {String} path or null
+ * @api private
+ */
+
+require.resolve = function(path) {
+  if (path.charAt(0) === '/') path = path.slice(1);
+  var index = path + '/index.js';
+
+  var paths = [
+    path,
+    path + '.js',
+    path + '.json',
+    path + '/index.js',
+    path + '/index.json'
+  ];
+
+  for (var i = 0; i < paths.length; i++) {
+    var path = paths[i];
+    if (has.call(require.modules, path)) return path;
+  }
+
+  if (has.call(require.aliases, index)) {
+    return require.aliases[index];
+  }
+};
+
+/**
+ * Normalize `path` relative to the current path.
+ *
+ * @param {String} curr
+ * @param {String} path
+ * @return {String}
+ * @api private
+ */
+
+require.normalize = function(curr, path) {
+  var segs = [];
+
+  if ('.' != path.charAt(0)) return path;
+
+  curr = curr.split('/');
+  path = path.split('/');
+
+  for (var i = 0; i < path.length; ++i) {
+    if ('..' == path[i]) {
+      curr.pop();
+    } else if ('.' != path[i] && '' != path[i]) {
+      segs.push(path[i]);
+    }
+  }
+
+  return curr.concat(segs).join('/');
+};
+
+/**
+ * Register module at `path` with callback `definition`.
+ *
+ * @param {String} path
+ * @param {Function} definition
+ * @api private
+ */
+
+require.register = function(path, definition) {
+  require.modules[path] = definition;
+};
+
+/**
+ * Alias a module definition.
+ *
+ * @param {String} from
+ * @param {String} to
+ * @api private
+ */
+
+require.alias = function(from, to) {
+  if (!has.call(require.modules, from)) {
+    throw new Error('Failed to alias "' + from + '", it does not exist');
+  }
+  require.aliases[to] = from;
+};
+
+/**
+ * Return a require function relative to the `parent` path.
+ *
+ * @param {String} parent
+ * @return {Function}
+ * @api private
+ */
+
+require.relative = function(parent) {
+  var p = require.normalize(parent, '..');
+
+  /**
+   * lastIndexOf helper.
+   */
+
+  function lastIndexOf(arr, obj) {
+    var i = arr.length;
+    while (i--) {
+      if (arr[i] === obj) return i;
+    }
+    return -1;
+  }
+
+  /**
+   * The relative require() itself.
+   */
+
+  function localRequire(path) {
+    var resolved = localRequire.resolve(path);
+    return require(resolved, parent, path);
+  }
+
+  /**
+   * Resolve relative to the parent.
+   */
+
+  localRequire.resolve = function(path) {
+    var c = path.charAt(0);
+    if ('/' == c) return path.slice(1);
+    if ('.' == c) return require.normalize(p, path);
+
+    // resolve deps by returning
+    // the dep in the nearest "deps"
+    // directory
+    var segs = parent.split('/');
+    var i = lastIndexOf(segs, 'deps') + 1;
+    if (!i) i = 0;
+    path = segs.slice(0, i + 1).join('/') + '/deps/' + path;
+    return path;
+  };
+
+  /**
+   * Check if module is defined at `path`.
+   */
+
+  localRequire.exists = function(path) {
+    return has.call(require.modules, localRequire.resolve(path));
+  };
+
+  return localRequire;
+};
+require.register("grunt-component-build-test/test/fixtures/index.js", function(exports, require, module){
+module.exports = 'test';
+});
+require.alias("grunt-component-build-test/test/fixtures/index.js", "grunt-component-build-test/index.js");
+

--- a/test/expected/standalone.css
+++ b/test/expected/standalone.css
@@ -1,0 +1,4 @@
+div {
+  margin: 0;
+  padding: 0;
+}

--- a/test/expected/standalone.js
+++ b/test/expected/standalone.js
@@ -1,0 +1,221 @@
+;(function(){
+
+
+/**
+ * hasOwnProperty.
+ */
+
+var has = Object.prototype.hasOwnProperty;
+
+/**
+ * Require the given path.
+ *
+ * @param {String} path
+ * @return {Object} exports
+ * @api public
+ */
+
+function require(path, parent, orig) {
+  var resolved = require.resolve(path);
+
+  // lookup failed
+  if (null == resolved) {
+    orig = orig || path;
+    parent = parent || 'root';
+    var err = new Error('Failed to require "' + orig + '" from "' + parent + '"');
+    err.path = orig;
+    err.parent = parent;
+    err.require = true;
+    throw err;
+  }
+
+  var module = require.modules[resolved];
+
+  // perform real require()
+  // by invoking the module's
+  // registered function
+  if (!module.exports) {
+    module.exports = {};
+    module.client = module.component = true;
+    module.call(this, module.exports, require.relative(resolved), module);
+  }
+
+  return module.exports;
+}
+
+/**
+ * Registered modules.
+ */
+
+require.modules = {};
+
+/**
+ * Registered aliases.
+ */
+
+require.aliases = {};
+
+/**
+ * Resolve `path`.
+ *
+ * Lookup:
+ *
+ *   - PATH/index.js
+ *   - PATH.js
+ *   - PATH
+ *
+ * @param {String} path
+ * @return {String} path or null
+ * @api private
+ */
+
+require.resolve = function(path) {
+  if (path.charAt(0) === '/') path = path.slice(1);
+  var index = path + '/index.js';
+
+  var paths = [
+    path,
+    path + '.js',
+    path + '.json',
+    path + '/index.js',
+    path + '/index.json'
+  ];
+
+  for (var i = 0; i < paths.length; i++) {
+    var path = paths[i];
+    if (has.call(require.modules, path)) return path;
+  }
+
+  if (has.call(require.aliases, index)) {
+    return require.aliases[index];
+  }
+};
+
+/**
+ * Normalize `path` relative to the current path.
+ *
+ * @param {String} curr
+ * @param {String} path
+ * @return {String}
+ * @api private
+ */
+
+require.normalize = function(curr, path) {
+  var segs = [];
+
+  if ('.' != path.charAt(0)) return path;
+
+  curr = curr.split('/');
+  path = path.split('/');
+
+  for (var i = 0; i < path.length; ++i) {
+    if ('..' == path[i]) {
+      curr.pop();
+    } else if ('.' != path[i] && '' != path[i]) {
+      segs.push(path[i]);
+    }
+  }
+
+  return curr.concat(segs).join('/');
+};
+
+/**
+ * Register module at `path` with callback `definition`.
+ *
+ * @param {String} path
+ * @param {Function} definition
+ * @api private
+ */
+
+require.register = function(path, definition) {
+  require.modules[path] = definition;
+};
+
+/**
+ * Alias a module definition.
+ *
+ * @param {String} from
+ * @param {String} to
+ * @api private
+ */
+
+require.alias = function(from, to) {
+  if (!has.call(require.modules, from)) {
+    throw new Error('Failed to alias "' + from + '", it does not exist');
+  }
+  require.aliases[to] = from;
+};
+
+/**
+ * Return a require function relative to the `parent` path.
+ *
+ * @param {String} parent
+ * @return {Function}
+ * @api private
+ */
+
+require.relative = function(parent) {
+  var p = require.normalize(parent, '..');
+
+  /**
+   * lastIndexOf helper.
+   */
+
+  function lastIndexOf(arr, obj) {
+    var i = arr.length;
+    while (i--) {
+      if (arr[i] === obj) return i;
+    }
+    return -1;
+  }
+
+  /**
+   * The relative require() itself.
+   */
+
+  function localRequire(path) {
+    var resolved = localRequire.resolve(path);
+    return require(resolved, parent, path);
+  }
+
+  /**
+   * Resolve relative to the parent.
+   */
+
+  localRequire.resolve = function(path) {
+    var c = path.charAt(0);
+    if ('/' == c) return path.slice(1);
+    if ('.' == c) return require.normalize(p, path);
+
+    // resolve deps by returning
+    // the dep in the nearest "deps"
+    // directory
+    var segs = parent.split('/');
+    var i = lastIndexOf(segs, 'deps') + 1;
+    if (!i) i = 0;
+    path = segs.slice(0, i + 1).join('/') + '/deps/' + path;
+    return path;
+  };
+
+  /**
+   * Check if module is defined at `path`.
+   */
+
+  localRequire.exists = function(path) {
+    return has.call(require.modules, localRequire.resolve(path));
+  };
+
+  return localRequire;
+};
+require.register("grunt-component-build-test/test/fixtures/index.js", function(exports, require, module){
+module.exports = 'test';
+});
+require.alias("grunt-component-build-test/test/fixtures/index.js", "grunt-component-build-test/index.js");
+
+if (typeof exports == "object") {
+  module.exports = require("grunt-component-build-test");
+} else if (typeof define == "function" && define.amd) {
+  define(require("grunt-component-build-test"));
+} else {
+  window["Test"] = require("grunt-component-build-test");
+}})();

--- a/test/expected/standalone.js
+++ b/test/expected/standalone.js
@@ -217,5 +217,5 @@ if (typeof exports == "object") {
 } else if (typeof define == "function" && define.amd) {
   define(require("grunt-component-build-test"));
 } else {
-  window["Test"] = require("grunt-component-build-test");
+  window["$"] = require("grunt-component-build-test");
 }})();

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,0 +1,1 @@
+module.exports = 'test';

--- a/test/fixtures/test.css
+++ b/test/fixtures/test.css
@@ -1,0 +1,4 @@
+div {
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
I added some tests that check generated files (Grunt) with expected files (Component-build()).
I currently use Makefile, to generate expected files, instead of a Grunt task because there are no plugin to run Shell commands compatible with Grunt 4.0. It could be changed later with [Grunt-shell](https://github.com/sindresorhus/grunt-shell) for example.

You just have to run `make` to generate expected files and `grunt` to test.

With this PR, tests are failing because of the outout of the stand-alone version of the component.
Since this commit (35a4ffbac37f941d69288d021e8537f9bebf9780) the `standalone` template is not processed correctly (for testing I've done). I'll patch it in another PR (see #8).
