### PR TITLE
Fix standalone output

### DIFF
--- a/lib/require.tmpl
+++ b/lib/require.tmpl
@@ -1,9 +1,8 @@
 ;(function(){
-  <%= require %>
-  <%= js %>
-  if ("undefined" == typeof module) {
-    window.<%= name %> = require("<%= name %>");
-  } else {
-    module.exports = require("<%= name %>");
-  }
-})();
+<%= require %><%= js %>if (typeof exports == "object") {
+  module.exports = require("<%= config.name %>");
+} else if (typeof define == "function" && define.amd) {
+  define(require("<%= config.name %>"));
+} else {
+  window["<%= name %>"] = require("<%= config.name %>");
+}})();

--- a/tasks/component.js
+++ b/tasks/component.js
@@ -104,9 +104,12 @@ module.exports = function(grunt) {
       if( opts.scripts !== false ) {
         var jsFile = path.join(output, name + '.js');
         if( opts.standalone ) {
-          obj.name = name;
+          // Defines the name of the global variable (window[opts.name]).
+          // By default we use the name defined in the component.json,
+          // else we use the `standalone` option defined in the Gruntfile.
+          obj.name = (typeof opts.standalone === 'string') ? opts.standalone : config.name;
           obj.config = config;
-          var string = grunt.template.process(template, obj);
+          var string = grunt.template.process(template, { data: obj });
           grunt.file.write(jsFile, string);
         }
         else {


### PR DESCRIPTION
I fixed the output of the "standalone" option to pass the tests (see #7)

I also updated the `standalone` option. Like the component-build() (-s flag), we can define the name of the global variable with the `standalone` value.

Sorry, the `require.tmpl` is less readable but it's simpler to test by comparing the output files. (Assuming that component-build() has correct output files).
