### PR TITLE
Fixed plugins: .conf to .config; use path relative to components

### DIFF
--- a/plugins/coffee.js
+++ b/plugins/coffee.js
@@ -5,16 +5,17 @@ var fs = require('fs');
 module.exports = function(builder) {
   builder.hook('before scripts', function(pkg){
 
-    pkg.conf.scripts.forEach(function(file, i, scripts){
+    pkg.config.scripts.forEach(function(file, i, scripts){
       if (path.extname(file) !== '.coffee') return;
-      var str = fs.readFileSync(file, 'utf8');
-      var compiled = coffee.compile(str, { filename : file, bare: true });
+      var filePath = path.resolve(path.join(pkg.dir, file));
+      var str = fs.readFileSync(filePath, 'utf8');
+      var compiled = coffee.compile(str, { filename : filePath, bare: true });
       var filename = file.replace('.coffee', '.js');
       pkg.addFile('scripts', filename, compiled);
     });
 
     // Remove all the coffee files from the scripts
-    pkg.conf.scripts = pkg.conf.scripts.filter(function(file){
+    pkg.config.scripts = pkg.config.scripts.filter(function(file){
       return path.extname(file) !== '.coffee';
     });
 

--- a/plugins/templates.js
+++ b/plugins/templates.js
@@ -4,10 +4,11 @@ var fs = require('fs');
 
 module.exports = function(builder) {
   builder.hook('before scripts', function(pkg){
-    if( !pkg.conf.templates ) return pkg;
-    pkg.conf.templates.forEach(function(file){
+    if( !pkg.config.templates ) return pkg;
+    pkg.config.templates.forEach(function(file){
       if (path.extname(file) !== '.html') return;
-      var str = fs.readFileSync(file, 'utf8');
+      var filePath = path.resolve(path.join(pkg.dir, file));
+      var str = fs.readFileSync(filePath, 'utf8');
       var compiled = strtojs(str);
       pkg.addFile('scripts', file.replace('.html','.js'), compiled);
     });


### PR DESCRIPTION
builder.js 0.7.0 changed .conf to .config:
https://github.com/component/builder.js/commit/f5289e3fe101a053f393bfc92ce8ffef81da20a3

The path of templates and coffee files was being used to read the file, but the path
needs to be relative to the component. Used path.resolve and path.join for this.

Note that there were no tests for plugins, and I didn't add any.
