### PR TITLE
Rename task to component_build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "0.8"
+  - "0.10"
+before_script:
+  - npm install -g grunt-cli

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
     },
 
     // Configuration to be run (and then tested).
-    component: {
+    component_build: {
       test_dev: {
         base: './test/fixtures/src',
         output: './tmp/dev',
@@ -72,7 +72,7 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'component', 'nodeunit']);
+  grunt.registerTask('test', ['clean', 'component_build', 'nodeunit']);
 
   // Default task.
   grunt.registerTask('default', ['jshint', 'test']);

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ grunt.loadNpmTasks('grunt-component-build');
 Add a component section to your Grunt file:
 
 ```js
-component: {
+component_build: {
   app: {
     output: './dist/',
     config: './component.json',
@@ -35,14 +35,14 @@ component: {
 }
 ```
 
-You can add as many sub-tasks to the component task and they will be compiled separately.
+You can add as many sub-tasks to the component_build task and they will be compiled separately.
 
 ## Extending Component with Plugins
 
 Builder.js allows us to extending it so we can add support for other languages, like Coffeescript or Jade. You can do this easily in the `configure` option in your grunt file.
 
 ```js
-component: {
+component_build: {
   app: {
     output: './dist/',
     config: './component.json',
@@ -67,7 +67,7 @@ These plugins are extremely simple. You can grab them from npm or write your own
 There are two plugins built into this grunt task. They compile Coffeescript and plain HTML. 
 
 ```js
-component: {
+component_build: {
   app: {
     output: './dist/',
     config: './component.json',

--- a/tasks/component_build.js
+++ b/tasks/component_build.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
   // TASKS
   // ==========================================================================
 
-  grunt.registerMultiTask('component', 'component-build for grunt.', function() {
+  grunt.registerMultiTask('component_build', 'component-build for grunt.', function() {
     var self = this;
     var opts = this.data;
     var name = opts.name || this.target;

--- a/test/component_build_test.js
+++ b/test/component_build_test.js
@@ -23,7 +23,7 @@ var read = grunt.file.read;
     test.ifError(value)
 */
 
-exports['component'] = {
+exports['component_build'] = {
 
 
   dev: function(test) {


### PR DESCRIPTION
The current _component_ task clashes with the grunt-component plugin, as described in #16.
