### PR TITLE
Add an option for verbose output (similar to component build -v)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-component-build",
   "description": "Build and watch Components",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "homepage": "https://github.com/anthonyshort/grunt-component-build",
   "author": {
     "name": "Anthony Short",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "coffee-script": "latest",
     "string-to-js": "latest",
-    "component-builder": "0.8.1"
+    "component-builder": "0.8.x"
   },
   "devDependencies": {
     "grunt": "~0.4.0",

--- a/tasks/component_build.js
+++ b/tasks/component_build.js
@@ -109,7 +109,7 @@ module.exports = function(grunt) {
         var cssFile = path.join(output, name + '.css');
         grunt.file.write(cssFile, obj.css.trim());
         
-        opts.verbose && grunt.log.writeln( 'write: ' + cssFile + ' (' + ( obj.css.trim().length / 1024 | 0 ) + 'kb)' );
+        opts.verbose && grunt.log.writeln( 'write: ' + path.join(self.data.output, name + '.css') + ' (' + ( obj.css.trim().length / 1024 | 0 ) + 'kb)' );
       }
 
       // Write JS file
@@ -123,7 +123,7 @@ module.exports = function(grunt) {
           obj.name = (typeof opts.standalone === 'string') ? opts.standalone : config.name;
           obj.config = config;
 
-          var string = grunt.template.process(template, { data: obj });
+          var string = grunt.template.process(template, { data: obj });
           grunt.file.write(jsFile, string);
           size = string.length;
         } else {
@@ -131,7 +131,7 @@ module.exports = function(grunt) {
           size = obj.require.length + obj.js.length;
         }
 
-        opts.verbose && grunt.log.writeln( 'write: ' + jsFile + ' (' + ( size / 1024 | 0 ) + 'kb)' );
+        opts.verbose && grunt.log.writeln( 'write: ' + path.join(self.data.output, name + '.js') + ' (' + ( size / 1024 | 0 ) + 'kb)' );
 
       }
 

--- a/tasks/component_build.js
+++ b/tasks/component_build.js
@@ -109,7 +109,7 @@ module.exports = function(grunt) {
         var cssFile = path.join(output, name + '.css');
         grunt.file.write(cssFile, obj.css.trim());
         
-        opts.verbose && grunt.log.writeln( 'write: ' + cssFile + ' (' + ( obj.css.trim().length / 1024 | 0 ) + 'kb)';
+        opts.verbose && grunt.log.writeln( 'write: ' + cssFile + ' (' + ( obj.css.trim().length / 1024 | 0 ) + 'kb)' );
       }
 
       // Write JS file

--- a/tasks/component_build.js
+++ b/tasks/component_build.js
@@ -93,6 +93,8 @@ module.exports = function(grunt) {
       opts.configure.call(this, builder);
     }
 
+    var start = new Date();
+    
     // Build the component
     builder.build(function(err, obj) {
       if (err) {
@@ -100,15 +102,20 @@ module.exports = function(grunt) {
         grunt.fatal(err.message);
       }
 
+      opts.verbose && grunt.log.writeln( 'duration: ' + ( new Date - start ) + 'ms' );
+      
       // Write CSS file
       if (opts.styles !== false) {
         var cssFile = path.join(output, name + '.css');
         grunt.file.write(cssFile, obj.css.trim());
+        
+        opts.verbose && grunt.log.writeln( 'write: ' + cssFile + ' (' + ( obj.css.trim().length / 1024 | 0 ) + 'kb)';
       }
 
       // Write JS file
       if (opts.scripts !== false) {
         var jsFile = path.join(output, name + '.js');
+        var size = 0;
         if (opts.standalone) {
           // Defines the name of the global variable (window[opts.name]).
           // By default we use the name defined in the component.json,
@@ -118,9 +125,14 @@ module.exports = function(grunt) {
 
           var string = grunt.template.process(template, { data: obj });
           grunt.file.write(jsFile, string);
+          size = string.length;
         } else {
           grunt.file.write(jsFile, obj.require + obj.js);
+          size = obj.require.length + obj.js.length;
         }
+
+        opts.verbose && grunt.log.writeln( 'write: ' + jsFile + ' (' + ( size / 1024 | 0 ) + 'kb)' );
+
       }
 
       done();


### PR DESCRIPTION
Example:

```
        component_build: {
            app: {
                base: 'client/',
                output: 'client/build/',
                styles: true,
                scripts: true,
                sourceUrls: true,
                verbose: true
            }
```

Will produce output like:

```
Running "component_build:app" (component_build) task
duration: 57ms
write: client/build/app.css (12kb)
write: client/build/app.js (214kb)
```

Added because I like to be able to keep an eye on the size of my app as I integrate components.
