### PR TITLE
Fix ignore option

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -46,7 +46,14 @@ module.exports = function(grunt, options) {
     if (options.ignore) {
       Object.keys(options.ignore).forEach(function(n) {
         var type = options.ignore[n];
-        builder.ignore(n, type);
+        
+        if (Array.isArray(type)) {
+          type.forEach(function(t) {
+            builder.ignore(n, t);
+          });
+        } else {
+          builder.ignore(n, type);
+        }
       });
     }
 


### PR DESCRIPTION
The builder expects `builder.ignore(name[string,array], type[string])`. However grunt-component-build was sending arrays for the type argument. It's been changed such that it loops the type array to send each element individually.
